### PR TITLE
fix: 画像の縦横比修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 gem 'sorcery'
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 gem 'rails-i18n'
 
 # Reduces boot times through caching; required in config/boot.rb
@@ -33,6 +33,7 @@ gem 'bootstrap', '~> 4.3.1'
 # rakuten API
 gem 'rakuten_web_service'
 gem "figaro"
+gem 'mini_magick', '~> 4.8'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     json (2.5.1)
@@ -113,6 +116,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.0)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -224,6 +228,8 @@ GEM
       rack (>= 1.1)
       rubocop (>= 0.90.0, < 2.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.2)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.4)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -285,8 +291,10 @@ DEPENDENCIES
   byebug
   factory_bot_rails
   figaro
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  mini_magick (~> 4.8)
   mysql2 (>= 0.4.4)
   pry
   pry-byebug

--- a/app/views/camps/_camp_image_list.erb
+++ b/app/views/camps/_camp_image_list.erb
@@ -6,7 +6,7 @@
           <%= link_to camp_path(camp_id: @camp.id, image_id: image.id), method: :patch, class: 'picture_delete_button', style: "display: none;" do %>
             <i class="fas fa-backspace fa-2x"></i>
           <%end%>
-          <%= image_tag(image, style: "width: 200px;height: 200px;display: inline-block;", class: "img-thumbnail") %>
+          <%= image_tag image.variant(combine_options:{gravity: :center, resize: "200x200^", crop:"200x200+0+0"}), class: "img-thumbnail" %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
・`mini_magick`と`active storage`の`variant`メソッドを使用して、画像のサムネイルをくりぬき式で正方形として表示